### PR TITLE
Fix Constraint.allows and Generator.getCandidates

### DIFF
--- a/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/CodeCollapsedEnumerationGenerator.kt
+++ b/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/CodeCollapsedEnumerationGenerator.kt
@@ -53,7 +53,7 @@ class CodeCollapsedEnumerationGenerator(
 
     override fun onCacheMissGeneration(constraints: List<Constraint>): Candidates {
         val solutions = codeSequence()
-            .filter { code -> constraints.all { it.candidate != code } }
+            .filter { code -> constraints.all { it.correct || it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, solutionPolicy) } }
             .toList()
 
@@ -78,7 +78,7 @@ class CodeCollapsedEnumerationGenerator(
         freshConstraints: List<Constraint>
     ): Candidates {
         val solutions = candidates.solutions.asSequence()
-            .filter { code -> freshConstraints.all { it.candidate != code } }
+            .filter { code -> freshConstraints.all { it.correct || it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, solutionPolicy) } }
             .toList()
 

--- a/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/CodeCollapsedEnumerationGenerator.kt
+++ b/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/CodeCollapsedEnumerationGenerator.kt
@@ -53,8 +53,8 @@ class CodeCollapsedEnumerationGenerator(
 
     override fun onCacheMissGeneration(constraints: List<Constraint>): Candidates {
         val solutions = codeSequence()
-            .filter { code -> constraints.all { it.correct || it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, solutionPolicy) } }
+            .filter { code -> constraints.all { it.candidate != code || it.correct } }
             .toList()
 
         val characterHistory = constraints.flatMap { it.candidate.asIterable() }.distinct()
@@ -66,8 +66,8 @@ class CodeCollapsedEnumerationGenerator(
         }
 
         val guesses = guessSource
-            .filter { code -> constraints.all { it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, guessPolicy) } }
+            .filter { code -> constraints.all { it.candidate != code } }
 
         return Candidates(guesses.toList(), solutions)
     }
@@ -78,8 +78,8 @@ class CodeCollapsedEnumerationGenerator(
         freshConstraints: List<Constraint>
     ): Candidates {
         val solutions = candidates.solutions.asSequence()
-            .filter { code -> freshConstraints.all { it.correct || it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, solutionPolicy) } }
+            .filter { code -> freshConstraints.all { it.candidate != code || it.correct } }
             .toList()
 
         // TODO attempt to filter the cached guesses. Requires that BOTH of the following are true:
@@ -94,8 +94,8 @@ class CodeCollapsedEnumerationGenerator(
         }
 
         val guesses = guessSource
-            .filter { code -> constraints.all { it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, guessPolicy) } }
+            .filter { code -> constraints.all { it.candidate != code } }
 
         return Candidates(guesses.toList(), solutions)
     }

--- a/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/CodeEnumeratingGenerator.kt
+++ b/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/CodeEnumeratingGenerator.kt
@@ -41,8 +41,8 @@ class CodeEnumeratingGenerator(
 
     override fun onCacheMissGeneration(constraints: List<Constraint>): Candidates {
         val solutions = codeSequence()
-            .filter { code -> constraints.all { it.correct || it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, solutionPolicy) } }
+            .filter { code -> constraints.all { it.candidate != code || it.correct } }
             .toList()
 
         val guessSource = if (truncateAtProduct == 0 || solutions.isEmpty()) {
@@ -52,8 +52,8 @@ class CodeEnumeratingGenerator(
         }
 
         val guesses = guessSource
-            .filter { code -> constraints.all { it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, guessPolicy) } }
+            .filter { code -> constraints.all { it.candidate != code } }
 
         return Candidates(guesses.toList(), solutions)
     }
@@ -64,8 +64,8 @@ class CodeEnumeratingGenerator(
         freshConstraints: List<Constraint>
     ): Candidates {
         val solutions = candidates.solutions.asSequence()
-            .filter { code -> freshConstraints.all { it.correct || it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, solutionPolicy) } }
+            .filter { code -> freshConstraints.all { it.candidate != code || it.correct } }
             .toList()
 
         // TODO attempt to filter the cached guesses; requires determining if they
@@ -77,8 +77,8 @@ class CodeEnumeratingGenerator(
         }
 
         val guesses = guessSource
-            .filter { code -> freshConstraints.all { it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, guessPolicy) } }
+            .filter { code -> freshConstraints.all { it.candidate != code } }
 
         return Candidates(guesses.toList(), solutions)
     }

--- a/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/CodeEnumeratingGenerator.kt
+++ b/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/CodeEnumeratingGenerator.kt
@@ -41,7 +41,7 @@ class CodeEnumeratingGenerator(
 
     override fun onCacheMissGeneration(constraints: List<Constraint>): Candidates {
         val solutions = codeSequence()
-            .filter { code -> constraints.all { it.candidate != code } }
+            .filter { code -> constraints.all { it.correct || it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, solutionPolicy) } }
             .toList()
 
@@ -64,7 +64,7 @@ class CodeEnumeratingGenerator(
         freshConstraints: List<Constraint>
     ): Candidates {
         val solutions = candidates.solutions.asSequence()
-            .filter { code -> freshConstraints.all { it.candidate != code } }
+            .filter { code -> freshConstraints.all { it.correct || it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, solutionPolicy) } }
             .toList()
 

--- a/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/VocabularyFileGenerator.kt
+++ b/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/VocabularyFileGenerator.kt
@@ -68,7 +68,7 @@ class VocabularyFileGenerator(
             .filter { code -> constraints.all { it.allows(code, guessPolicy) } }
 
         val solutions = solutionVocabulary.asSequence()
-            .filter { code -> constraints.all { it.candidate != code } }
+            .filter { code -> constraints.all { it.correct || it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, solutionPolicy) } }
 
         return Candidates(guesses.toList(), solutions.toList())
@@ -84,7 +84,7 @@ class VocabularyFileGenerator(
             .filter { code -> freshConstraints.all { it.allows(code, guessPolicy) } }
 
         val solutions = candidates.solutions.asSequence()
-            .filter { code -> freshConstraints.all { it.candidate != code } }
+            .filter { code -> freshConstraints.all { it.correct || it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, solutionPolicy) } }
 
         return Candidates(guesses.toList(), solutions.toList())

--- a/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/VocabularyFileGenerator.kt
+++ b/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/VocabularyFileGenerator.kt
@@ -64,12 +64,12 @@ class VocabularyFileGenerator(
 
     override fun onCacheMissGeneration(constraints: List<Constraint>): Candidates {
         val guesses = guessVocabulary.asSequence()
-            .filter { code -> constraints.all { it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, guessPolicy) } }
+            .filter { code -> constraints.all { it.candidate != code } }
 
         val solutions = solutionVocabulary.asSequence()
-            .filter { code -> constraints.all { it.correct || it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, solutionPolicy) } }
+            .filter { code -> constraints.all { it.candidate != code || it.correct } }
 
         return Candidates(guesses.toList(), solutions.toList())
     }
@@ -80,12 +80,12 @@ class VocabularyFileGenerator(
         freshConstraints: List<Constraint>
     ): Candidates {
         val guesses = candidates.guesses.asSequence()
-            .filter { code -> freshConstraints.all { it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, guessPolicy) } }
+            .filter { code -> freshConstraints.all { it.candidate != code } }
 
         val solutions = candidates.solutions.asSequence()
-            .filter { code -> freshConstraints.all { it.correct || it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, solutionPolicy) } }
+            .filter { code -> freshConstraints.all { it.candidate != code || it.correct } }
 
         return Candidates(guesses.toList(), solutions.toList())
     }

--- a/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/VocabularyListGenerator.kt
+++ b/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/VocabularyListGenerator.kt
@@ -28,12 +28,12 @@ class VocabularyListGenerator(
 
     override fun onCacheMissGeneration(constraints: List<Constraint>): Candidates {
         val guesses = guessVocabulary.asSequence()
-            .filter { code -> constraints.all { it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, guessPolicy) } }
+            .filter { code -> constraints.all { it.candidate != code } }
 
         val solutions = solutionVocabulary.asSequence()
-            .filter { code -> constraints.all { it.correct || it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, solutionPolicy) } }
+            .filter { code -> constraints.all { it.candidate != code || it.correct } }
 
         return Candidates(guesses.toList(), solutions.toList())
     }
@@ -44,12 +44,12 @@ class VocabularyListGenerator(
         freshConstraints: List<Constraint>
     ): Candidates {
         val guesses = candidates.guesses.asSequence()
-            .filter { code -> freshConstraints.all { it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, guessPolicy) } }
+            .filter { code -> freshConstraints.all { it.candidate != code } }
 
         val solutions = candidates.solutions.asSequence()
-            .filter { code -> freshConstraints.all { it.correct || it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, solutionPolicy) } }
+            .filter { code -> freshConstraints.all { it.candidate != code || it.correct } }
 
         return Candidates(guesses.toList(), solutions.toList())
     }

--- a/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/VocabularyListGenerator.kt
+++ b/game/src/main/java/com/peaceray/codeword/game/bot/modules/generation/VocabularyListGenerator.kt
@@ -32,7 +32,7 @@ class VocabularyListGenerator(
             .filter { code -> constraints.all { it.allows(code, guessPolicy) } }
 
         val solutions = solutionVocabulary.asSequence()
-            .filter { code -> constraints.all { it.candidate != code } }
+            .filter { code -> constraints.all { it.correct || it.candidate != code } }
             .filter { code -> constraints.all { it.allows(code, solutionPolicy) } }
 
         return Candidates(guesses.toList(), solutions.toList())
@@ -48,7 +48,7 @@ class VocabularyListGenerator(
             .filter { code -> freshConstraints.all { it.allows(code, guessPolicy) } }
 
         val solutions = candidates.solutions.asSequence()
-            .filter { code -> freshConstraints.all { it.candidate != code } }
+            .filter { code -> freshConstraints.all { it.correct || it.candidate != code } }
             .filter { code -> freshConstraints.all { it.allows(code, solutionPolicy) } }
 
         return Candidates(guesses.toList(), solutions.toList())

--- a/game/src/main/java/com/peaceray/codeword/game/data/Constraint.kt
+++ b/game/src/main/java/com/peaceray/codeword/game/data/Constraint.kt
@@ -230,8 +230,12 @@ data class Constraint private constructor(val candidate: String, val markup: Lis
             else -> {
                 val zipped = candidate.zip(guess)
 
-                // find an exact match that is not satisfied (among guess characters)
-                if (zipped.filterIndexed { index, _ -> markup[index] == MarkupType.EXACT }.any { it.first != it.second }) {
+                // find an exact markup that is not satisfied, or an exact match that is not marked up
+                if (zipped.withIndex().any {
+                        val markedExact = markup[it.index] == MarkupType.EXACT
+                        val isExact = it.value.first == it.value.second
+                        markedExact != isExact
+                    }) {
                     return false
                 }
 
@@ -308,9 +312,11 @@ data class Constraint private constructor(val candidate: String, val markup: Lis
             else -> {
                 val zipped = candidate.zip(guess)
 
-                // find exact matches that are not satisfied
+                // find an exact markup that is not satisfied, or an exact match that is not marked up
                 zipped.forEachIndexed { index, pair ->
-                    if (markup[index] == MarkupType.EXACT && pair.first != pair.second) {
+                    val markedExact = markup[index] == MarkupType.EXACT
+                    val isExact = pair.first == pair.second
+                    if (markedExact != isExact) {
                         list.add(Violation(this, guess, index, index))
                     }
                 }


### PR DESCRIPTION
**Constraint.allows() previously accepted candidates with un-annotated EXACT matches.**

Motivating case: Constraint.create("frill", "click").allows("civil", ConstraintPolicy.POSITIVE) returns true, should return false. The check for EXACT matches was one-directional: any position marked "EXACT" must be matched in the candidate, but the case where a position not marked "EXACT" had the same letters was not checked.

This fix also applies to Constraint.violations(), a similar function.

**CandidateGenerationModules now allow correct Constraints as "solutions".**

Obviously, a Constraint that indicates the guess is correct should not eliminate that guess as a potential solution. In practice, this only applies after a game is over, so it shouldn't have affected anything in normal play (just debugging scenarios like use of Evaluator.peek()).

**Optimization: reorder Generator Candidate filtering for better efficiency (earlier elimination).**