### PR TITLE
Feature: hold "delete" to fully erase guess.

### DIFF
--- a/app/src/main/java/com/peaceray/codeword/presentation/view/component/views/CodeKeyboardView.kt
+++ b/app/src/main/java/com/peaceray/codeword/presentation/view/component/views/CodeKeyboardView.kt
@@ -35,6 +35,7 @@ class CodeKeyboardView: ConstraintLayout {
         fun onCharacter(character: Char)
         fun onEnter()
         fun onDelete()
+        fun onDeleteFully()
     }
 
     var onKeyListener: OnKeyListener? = null
@@ -56,6 +57,23 @@ class CodeKeyboardView: ConstraintLayout {
                 view is CodeKeyView -> Timber.v("onClick: DISABLED ${view.type} (${view.character})")
                 else -> Timber.v("onClickListener invoked for non-CodeKeyView $view")
             }
+        }
+    }
+
+    private val onKeyLongClickListener = object: OnLongClickListener {
+        override fun onLongClick(view: View?): Boolean {
+            when {
+                view is CodeKeyView && isEnabled -> {
+                    Timber.v("onLongClick: ENABLED ${view.type} (${view.character})")
+                    if (view.type == CodeKeyView.KeyType.DELETE) {
+                        onKeyListener?.onDeleteFully()
+                        return true
+                    }
+                }
+                view is CodeKeyView -> Timber.v("onLongClick: DISABLED ${view.type} (${view.character})")
+                else -> Timber.v("onLongClickListener invoked for non-CodeKeyView $view")
+            }
+            return false
         }
     }
     //---------------------------------------------------------------------------------------------
@@ -127,6 +145,7 @@ class CodeKeyboardView: ConstraintLayout {
         // Assumption: Keys do not contain each other.
         if (parent is CodeKeyView) {
             parent.setOnClickListener(onKeyClickListener)
+            parent.setOnLongClickListener(onKeyLongClickListener)
             keys.add(parent)
         } else if (parent is ViewGroup) {
             parent.children.forEach { traverse(it) }

--- a/app/src/main/java/com/peaceray/codeword/presentation/view/fragments/GameFragment.kt
+++ b/app/src/main/java/com/peaceray/codeword/presentation/view/fragments/GameFragment.kt
@@ -365,6 +365,13 @@ class GameFragment: Fragment(R.layout.fragment_game), GameContract.View {
                 presenter.onGuessUpdated(guess, guess.dropLast(1))
             }
         }
+
+        override fun onDeleteFully() {
+            val guess = guessAdapter.guesses.lastOrNull()?.candidate ?: ""
+            if (guess.isNotEmpty()) {
+                presenter.onGuessUpdated(guess, "")
+            }
+        }
     }
 
     private fun onKeyboardStyleUpdate(characters: Iterable<Char>, locale: Locale?) {


### PR DESCRIPTION
Guess deletion is frustrating for long words. Now: just hold "Delete" to erase the whole guess.