### PR TITLE
Feature/reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ gen/
 out/
 #  Uncomment the following line in case you need and you don't have the release build type files in your app
 release/
+releaseReproducible/
 
 # Console save files
 save_data/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,6 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 
     testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
         }
+        releaseReproducible {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
+        }
     }
     namespace 'com.peaceray.codeword'
 }
@@ -84,4 +89,48 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}
+
+// Use repro-apk tools to ensure the releaseReproducible build is reproducible
+// by e.g. F-Droid when 'release' build used in their reproducible flow.
+// Prefer the "release" build type unless running in a context configured
+// to match these filepaths and with no additional post-processing.
+android {
+    applicationVariants.all { variant ->
+        def buildType = variant.buildType.name
+
+        if (buildType.toLowerCase().contains("reproducible")) {
+            variant.outputs.each { output ->
+                variant.packageApplicationProvider.get().doLast {
+                    exec {
+                        // set ANDROID_HOME for zipalign
+                        environment "ANDROID_HOME", android.sdkDirectory
+                        commandLine(
+                                "py", "../../../../Tools/repro_apk/inplace_fix.py",
+                                "--zipalign", "fix-newlines", output.outputFile,
+                                "META-INF/assets/*.txt", "META-INF/assets/*.html", "META-INF/assets/*.css",
+                                "assets/*.txt", "assets/*.html", "assets/*.css"
+                        )
+                    }
+                    // re-sign w/ apksigner if needed
+                    if (variant.signingConfig != null) {
+                        def tools = "${android.sdkDirectory}/build-tools/${android.buildToolsVersion}"
+                        def sc = variant.signingConfig
+                        exec {
+                            environment "KS_PASS", sc.storePassword
+                            environment "KEY_PASS", sc.keyPassword
+                            commandLine(
+                                    "${tools}/apksigner.bat", "sign", "-v",
+                                    "--ks", sc.storeFile,
+                                    "--ks-pass", "env:KS_PASS",
+                                    "--ks-key-alias", sc.keyAlias,
+                                    "--key-pass", "env:KEY_PASS",
+                                    output.outputFile
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/peaceray/codeword/glue/modules/android/ContextModules.kt
+++ b/app/src/main/java/com/peaceray/codeword/glue/modules/android/ContextModules.kt
@@ -1,4 +1,4 @@
-package com.peaceray.codeword.glue.modules
+package com.peaceray.codeword.glue.modules.android
 
 import android.app.Activity
 import android.app.Application
@@ -7,6 +7,7 @@ import android.content.res.AssetManager
 import android.content.res.Resources
 import com.peaceray.codeword.glue.ForActivity
 import com.peaceray.codeword.glue.ForApplication
+import com.peaceray.codeword.glue.utils.optional.OptionalUtils
 import dagger.BindsOptionalOf
 import dagger.Module
 import dagger.Provides
@@ -99,17 +100,17 @@ object ContextModule {
     fun provideContext(
         @ForApplication context: Context,
         @ForActivity activityContext: Optional<Context>
-    ): Context = activityContext.orElse(context)
+    ): Context = OptionalUtils.orElse(activityContext, context)
 
     @Provides
     fun provideResources(
         @ForApplication resources: Resources,
         @ForActivity activityResources: Optional<Resources>
-    ): Resources = activityResources.orElse(resources)
+    ): Resources = OptionalUtils.orElse(activityResources, resources)
 
     @Provides
     fun provideAssets(
         @ForApplication assets: AssetManager,
         @ForActivity activityAssets: Optional<AssetManager>
-    ): AssetManager = activityAssets.orElse(assets)
+    ): AssetManager = OptionalUtils.orElse(activityAssets, assets)
 }

--- a/app/src/main/java/com/peaceray/codeword/glue/modules/android/LayoutInflaterModules.kt
+++ b/app/src/main/java/com/peaceray/codeword/glue/modules/android/LayoutInflaterModules.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import androidx.fragment.app.Fragment
 import com.peaceray.codeword.glue.ForActivity
 import com.peaceray.codeword.glue.ForFragment
+import com.peaceray.codeword.glue.utils.optional.OptionalUtils
 import dagger.BindsOptionalOf
 import dagger.Module
 import dagger.Provides
@@ -48,5 +49,5 @@ object LayoutInflaterModule {
     fun provideLayoutInflater(
         @ForActivity inflater: LayoutInflater,
         @ForFragment fragmentLayoutInflater: Optional<LayoutInflater>
-    ): LayoutInflater = fragmentLayoutInflater.orElse(inflater)
+    ): LayoutInflater = OptionalUtils.orElse(fragmentLayoutInflater, inflater)
 }

--- a/app/src/main/java/com/peaceray/codeword/glue/modules/android/SystemServiceModules.kt
+++ b/app/src/main/java/com/peaceray/codeword/glue/modules/android/SystemServiceModules.kt
@@ -8,6 +8,7 @@ import android.content.res.AssetManager
 import android.content.res.Resources
 import com.peaceray.codeword.glue.ForActivity
 import com.peaceray.codeword.glue.ForApplication
+import com.peaceray.codeword.glue.utils.optional.OptionalUtils
 import dagger.BindsOptionalOf
 import dagger.Module
 import dagger.Provides
@@ -53,5 +54,5 @@ object SystemServiceModule {
     fun provideClipboardManager(
         @ForApplication clipboardManager: ClipboardManager,
         @ForActivity activityClipboardManager: Optional<ClipboardManager>
-    ): ClipboardManager = activityClipboardManager.orElse(clipboardManager)
+    ): ClipboardManager = OptionalUtils.orElse(activityClipboardManager, clipboardManager)
 }

--- a/app/src/main/java/com/peaceray/codeword/glue/utils/optional/OptionalUtils.kt
+++ b/app/src/main/java/com/peaceray/codeword/glue/utils/optional/OptionalUtils.kt
@@ -1,0 +1,24 @@
+package com.peaceray.codeword.glue.utils.optional
+
+import android.os.Build
+import java.util.Optional
+
+class OptionalUtils {
+
+    companion object {
+        private val implementation = if (Build.VERSION.SDK_INT >= 24) {
+            OptionalUtilsAPI24()
+        } else {
+            OptionalUtilsAPIFallback()
+        }
+
+        fun <T> orElse(firstOption: Optional<T>, secondOption: T): T {
+            return implementation.optionalOrElse(firstOption, secondOption)
+        }
+    }
+
+    internal interface Implementation {
+        fun <T> optionalOrElse(firstOption: Optional<T>, secondOption: T): T
+    }
+
+}

--- a/app/src/main/java/com/peaceray/codeword/glue/utils/optional/OptionalUtilsAPI24.kt
+++ b/app/src/main/java/com/peaceray/codeword/glue/utils/optional/OptionalUtilsAPI24.kt
@@ -1,0 +1,11 @@
+package com.peaceray.codeword.glue.utils.optional
+
+import androidx.annotation.RequiresApi
+import java.util.Optional
+
+@RequiresApi(24)
+internal class OptionalUtilsAPI24: OptionalUtils.Implementation {
+
+    override fun <T> optionalOrElse(firstOption: Optional<T>, secondOption: T): T = firstOption.orElse(secondOption)
+
+}

--- a/app/src/main/java/com/peaceray/codeword/glue/utils/optional/OptionalUtilsAPIFallback.kt
+++ b/app/src/main/java/com/peaceray/codeword/glue/utils/optional/OptionalUtilsAPIFallback.kt
@@ -1,0 +1,7 @@
+package com.peaceray.codeword.glue.utils.optional
+
+import java.util.Optional
+
+internal class OptionalUtilsAPIFallback: OptionalUtils.Implementation {
+    override fun <T> optionalOrElse(firstOption: Optional<T>, secondOption: T) = secondOption
+}

--- a/app/src/main/java/com/peaceray/codeword/presentation/view/activities/GameSetupActivity.kt
+++ b/app/src/main/java/com/peaceray/codeword/presentation/view/activities/GameSetupActivity.kt
@@ -151,10 +151,12 @@ class GameSetupActivity:
         else -> super.onOptionsItemSelected(item)
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         // pass to fragment
         if (isSetup) {
             binding.fragmentContainerView.getFragment<GameSetupFragment>().onCancelButtonClicked()
+            super.onBackPressed()
         } else {
             binding.fragmentContainerView.getFragment<GameInfoFragment>().onLaunchButtonClicked()
         }

--- a/app/src/main/res/layout/cell_histogram_row.xml
+++ b/app/src/main/res/layout/cell_histogram_row.xml
@@ -32,6 +32,7 @@
         android:id="@+id/histogramBiasView"
         android:layout_width="1dp"
         android:layout_height="1dp"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toEndOf="@id/roundTextView"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginStart="@dimen/histogram_minimum_width"


### PR DESCRIPTION
Add a buildType for reproducible builds. It uses absolute tool paths to reference repro_apk, so should only be used in a similarly configured build environment without any further postprocessing; other contexts (for example F-Droid release builds) should apply the same reproducibility tools in a different build pipeline.